### PR TITLE
prevent race condition when installing the splash image

### DIFF
--- a/recipes-bsp/linux/linux-qviart_4.2.1.bb
+++ b/recipes-bsp/linux/linux-qviart_4.2.1.bb
@@ -49,3 +49,6 @@ pkg_postinst_kernel-image () {
     fi
     true
 }
+
+# extra tasks
+addtask kernel_link_images after do_compile before do_install


### PR DESCRIPTION
This was addded to the Xsarius recipe some time ago, but not to this one.